### PR TITLE
@tryghost/release-utils

### DIFF
--- a/packages/release-utils/.eslintrc.js
+++ b/packages/release-utils/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node',
+    ]
+};

--- a/packages/release-utils/LICENSE
+++ b/packages/release-utils/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Ghost Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/release-utils/README.md
+++ b/packages/release-utils/README.md
@@ -1,0 +1,39 @@
+# Release Utils
+
+## Install
+
+`npm install @tryghost/release-utils --save`
+
+or
+
+`yarn add @tryghost/release-utils`
+
+
+## Usage
+
+
+## Develop
+
+This is a mono repository, managed with [lerna](https://lernajs.io/).
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+## Run
+
+- `yarn dev`
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+
+
+
+
+# Copyright & License
+
+Copyright (c) 2019 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/packages/release-utils/README.md
+++ b/packages/release-utils/README.md
@@ -52,13 +52,13 @@ changelog
         githubRepoPath: String
         lastVersion: String
         append: Boolean [optional, Default: false],
-        folder: String
+        folder: String [optional, Path on Disk]
     })
     .sort()
     .clean()
 ```
 
-Create Release:
+Create & Upload Release:
 
 ```
 const releaseUtils = require('@tryghost/release-utils');
@@ -81,6 +81,18 @@ releaseUtils
         draft: Boolean [optional, Default: true],
         filterEmojiCommits: Boolean [optional, Default: true]
     });
+    
+releaseUtils
+    .releases
+    .uploadZip({
+        github: {
+            username: String,
+            token: String
+        },
+        zipPath: String [Path on Disk],
+        uri: String,
+        userAgent: String
+    })
 ```
 
 

--- a/packages/release-utils/README.md
+++ b/packages/release-utils/README.md
@@ -11,6 +11,78 @@ or
 
 ## Usage
 
+Create Gist:
+
+```
+const releaseUtils = require('@tryghost/release-utils');
+
+
+releaseUtils
+    .gist
+    .create({
+        userAgent: String,
+        gistName: String,
+        gistDescription: String,
+        changelogPath: String [Path on Disk]
+        github: {
+            username: String
+            token: String
+        },
+        isPublic: Boolean [optional, Default: true]
+    })
+```
+
+Create Changelog:
+
+```
+const releaseUtils = require('@tryghost/release-utils');
+
+
+const changelog = new releaseUtils.Changelog({
+    changelogPath: String [Path on Disk],
+    folder: String [Path on Disk]
+});
+
+changelog
+    .write({
+        githubRepoPath: String,
+        lastVersion: String
+    })
+    .write({
+        githubRepoPath: String
+        lastVersion: String
+        append: Boolean [optional, Default: false],
+        folder: String
+    })
+    .sort()
+    .clean()
+```
+
+Create Release:
+
+```
+const releaseUtils = require('@tryghost/release-utils');
+
+
+releaseUtils
+    .releases
+    .create({
+        tagName: String,
+        releaseName: String,
+        userAgent: String,
+        uri: String,
+        github: {
+            username: String,
+            token: String,
+        },
+        changelogPath: String [Path on Disk],
+        gistUrl: String [optional],
+        preRelease: Boolean [optional, Default: false],
+        draft: Boolean [optional, Default: true],
+        filterEmojiCommits: Boolean [optional, Default: true]
+    });
+```
+
 
 ## Develop
 

--- a/packages/release-utils/lib/changelog.js
+++ b/packages/release-utils/lib/changelog.js
@@ -31,7 +31,6 @@ class Changelog {
         ];
 
         _.each(commands, (command) => {
-            console.log(command);
             execa.shellSync(command, {cwd: options.folder || this.folder});
         });
 

--- a/packages/release-utils/lib/changelog.js
+++ b/packages/release-utils/lib/changelog.js
@@ -1,28 +1,24 @@
 const execa = require('execa');
 const _ = require('lodash');
 
+const localUtils = require('./utils');
+
 class Changelog {
     constructor(options = {}) {
-        if (!options.folder) {
-            throw new Error('folder required.');
-        }
-
-        if (!options.changelogPath) {
-            throw new Error('changelogPath required.');
-        }
+        localUtils.checkMissingOptions(options,
+            'folder',
+            'changelogPath'
+        );
 
         this.changelogPath = options.changelogPath;
         this.folder = options.folder;
     }
 
     write(options = {}) {
-        if (!options.githubRepoPath) {
-            throw new Error('githubRepoPath required.');
-        }
-
-        if (!options.lastVersion) {
-            throw new Error('lastVersion required.');
-        }
+        localUtils.checkMissingOptions(options,
+            'githubRepoPath',
+            'lastVersion'
+        );
 
         let sign = '>';
 

--- a/packages/release-utils/lib/changelog.js
+++ b/packages/release-utils/lib/changelog.js
@@ -1,0 +1,58 @@
+const execa = require('execa');
+const _ = require('lodash');
+
+class Changelog {
+    constructor(options = {}) {
+        if (!options.folder) {
+            throw new Error('folder required.');
+        }
+
+        if (!options.changelogPath) {
+            throw new Error('changelogPath required.');
+        }
+
+        this.changelogPath = options.changelogPath;
+        this.folder = options.folder;
+    }
+
+    write(options = {}) {
+        if (!options.githubRepoPath) {
+            throw new Error('githubRepoPath required.');
+        }
+
+        if (!options.lastVersion) {
+            throw new Error('lastVersion required.');
+        }
+
+        let sign = '>';
+
+        if (options.append) {
+            sign = '>>';
+        }
+
+        const commands = [
+            `git log --no-merges --pretty=tformat:'%at * [%h](${options.githubRepoPath}/commit/%h) %s - %an' ${options.lastVersion}.. ${sign} ${this.changelogPath}`
+        ];
+
+        _.each(commands, (command) => {
+            console.log(command);
+            execa.shellSync(command, {cwd: options.folder || this.folder});
+        });
+
+        return this;
+    }
+
+    sort() {
+        execa.shellSync(`sort -r ${this.changelogPath} -o ${this.changelogPath}`, {cwd: this.folder});
+
+        return this;
+    }
+
+    clean() {
+        execa.shellSync(`sed -i.bk -E 's/^[0-9]{10} //g' ${this.changelogPath}`, {cwd: this.folder});
+
+        return this;
+    }
+}
+
+module.exports = Changelog;

--- a/packages/release-utils/lib/gist.js
+++ b/packages/release-utils/lib/gist.js
@@ -1,36 +1,20 @@
 const fs = require('fs');
 const requestPromise = require('request-promise');
 
+const localUtils = require('./utils');
+
 module.exports.create = (options = {}) => {
     let isPublic = true;
 
-    if (!options.changelogPath) {
-        throw new Error('changelogPath is required.');
-    }
-
-    if (!options.gistName) {
-        throw new Error('gistName is required.');
-    }
-
-    if (!options.gistDescription) {
-        throw new Error('gistDescription is required.');
-    }
-
-    if (!options.github) {
-        throw new Error('github is required.');
-    }
-
-    if (!options.github.username) {
-        throw new Error('github username is required.');
-    }
-
-    if (!options.github.token) {
-        throw new Error('github token is required.');
-    }
-
-    if (!options.userAgent) {
-        throw new Error('userAgent is required.');
-    }
+    localUtils.checkMissingOptions(options,
+        'changelogPath',
+        'gistName',
+        'gistDescription',
+        'github',
+        'github.username',
+        'github.token',
+        'userAgent'
+    );
 
     if (options.hasOwnProperty('isPublic')) {
         isPublic = options.isPublic;

--- a/packages/release-utils/lib/gist.js
+++ b/packages/release-utils/lib/gist.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const requestPromise = require('request-promise');
+
+module.exports.create = (options = {}) => {
+    let isPublic = true;
+
+    if (!options.changelogPath) {
+        throw new Error('changelogPath is required.');
+    }
+
+    if (!options.gistName) {
+        throw new Error('gistName is required.');
+    }
+
+    if (!options.gistDescription) {
+        throw new Error('gistDescription is required.');
+    }
+
+    if (!options.github) {
+        throw new Error('github is required.');
+    }
+
+    if (!options.github.username) {
+        throw new Error('github username is required.');
+    }
+
+    if (!options.github.token) {
+        throw new Error('github token is required.');
+    }
+
+    if (!options.userAgent) {
+        throw new Error('userAgent is required.');
+    }
+
+    if (options.hasOwnProperty('isPublic')) {
+        isPublic = options.isPublic;
+    }
+
+    const content = fs.readFileSync(options.changelogPath);
+    const files = {};
+
+    files[options.gistName] = {
+        content: content.toString('utf8')
+    };
+
+    const auth = 'Basic ' + new Buffer(options.github.username + ':' + options.github.token).toString('base64');
+
+    const reqOptions = {
+        uri: 'https://api.github.com/gists',
+        headers: {
+            'User-Agent': options.userAgent,
+            Authorization: auth
+        },
+        method: 'POST',
+        body: {
+            description: options.gistDescription,
+            public: isPublic,
+            files: files
+        },
+        json: true,
+        resolveWithFullResponse: true
+    };
+
+    return requestPromise(reqOptions)
+        .then((response) => {
+            return {
+                gistUrl: response.body.html_url
+            };
+        });
+};

--- a/packages/release-utils/lib/index.js
+++ b/packages/release-utils/lib/index.js
@@ -1,0 +1,17 @@
+module.exports = {
+    get Changelog() {
+        return require('./changelog');
+    },
+
+    get releases() {
+        return require('./releases');
+    },
+
+    get gist() {
+        return require('./gist');
+    },
+
+    get utils() {
+        return require('./utils');
+    }
+};

--- a/packages/release-utils/lib/releases.js
+++ b/packages/release-utils/lib/releases.js
@@ -10,37 +10,16 @@ module.exports.draft = (options = {}) => {
     let draft = true;
     let prerelease = false;
 
-    if (!options.changelogPath) {
-        throw new Error('changelogPath is required.');
-    }
-
-    if (!options.github) {
-        throw new Error('github is required.');
-    }
-
-    if (!options.github.username) {
-        throw new Error('github username is required.');
-    }
-
-    if (!options.github.token) {
-        throw new Error('github token is required.');
-    }
-
-    if (!options.userAgent) {
-        throw new Error('userAgent is required.');
-    }
-
-    if (!options.uri) {
-        throw new Error('uri is required.');
-    }
-
-    if (!options.tagName) {
-        throw new Error('tagName is required.');
-    }
-
-    if (!options.releaseName) {
-        throw new Error('releaseName is required.');
-    }
+    localUtils.checkMissingOptions(options,
+        'changelogPath',
+        'github',
+        'github.username',
+        'github.token',
+        'userAgent',
+        'uri',
+        'tagName',
+        'releaseName'
+    );
 
     if (options.hasOwnProperty('draft')) {
         draft = options.draft;
@@ -94,29 +73,14 @@ module.exports.draft = (options = {}) => {
 };
 
 module.exports.uploadZip = (options = {}) => {
-    if (!options.github) {
-        throw new Error('github is required.');
-    }
-
-    if (!options.github.username) {
-        throw new Error('github username is required.');
-    }
-
-    if (!options.github.token) {
-        throw new Error('github token is required.');
-    }
-
-    if (!options.zipPath) {
-        throw new Error('github zipPath is required.');
-    }
-
-    if (!options.userAgent) {
-        throw new Error('userAgent is required.');
-    }
-
-    if (!options.uri) {
-        throw new Error('uri is required.');
-    }
+    localUtils.checkMissingOptions(options,
+        'zipPath',
+        'github',
+        'github.username',
+        'github.token',
+        'userAgent',
+        'uri'
+    );
 
     const auth = 'Basic ' + new Buffer(options.github.username + ':' + options.github.token).toString('base64');
     const stats = fs.statSync(options.zipPath);
@@ -149,13 +113,10 @@ module.exports.uploadZip = (options = {}) => {
 };
 
 module.exports.get = (options = {}) => {
-    if (!options.userAgent) {
-        throw new Error('userAgent is required.');
-    }
-
-    if (!options.uri) {
-        throw new Error('uri is required.');
-    }
+    localUtils.checkMissingOptions(options,
+        'userAgent',
+        'uri'
+    );
 
     const reqOptions = {
         uri: options.uri,

--- a/packages/release-utils/lib/releases.js
+++ b/packages/release-utils/lib/releases.js
@@ -6,7 +6,7 @@ const request = require('request');
 
 const localUtils = require('./utils');
 
-module.exports.draft = (options = {}) => {
+module.exports.create = (options = {}) => {
     let draft = true;
     let prerelease = false;
     let filterEmojiCommits = true;

--- a/packages/release-utils/lib/releases.js
+++ b/packages/release-utils/lib/releases.js
@@ -9,6 +9,7 @@ const localUtils = require('./utils');
 module.exports.draft = (options = {}) => {
     let draft = true;
     let prerelease = false;
+    let filterEmojiCommits = true;
 
     localUtils.checkMissingOptions(options,
         'changelogPath',
@@ -29,8 +30,15 @@ module.exports.draft = (options = {}) => {
         prerelease = options.prerelease;
     }
 
+    if (options.hasOwnProperty('filterEmojiCommits')) {
+        filterEmojiCommits = options.filterEmojiCommits;
+    }
+
     let content = fs.readFileSync(options.changelogPath).toString('utf8').split(os.EOL);
-    content = localUtils.getEmojiCommits(content);
+
+    if (filterEmojiCommits) {
+        content = localUtils.filterEmojiCommits(content);
+    }
 
     content = content.filter((item) => {
         return item !== undefined;

--- a/packages/release-utils/lib/releases.js
+++ b/packages/release-utils/lib/releases.js
@@ -1,0 +1,173 @@
+const fs = require('fs');
+const os = require('os');
+const Promise = require('bluebird');
+const requestPromise = require('request-promise');
+const request = require('request');
+
+const localUtils = require('./utils');
+
+module.exports.draft = (options = {}) => {
+    let draft = true;
+    let prerelease = false;
+
+    if (!options.changelogPath) {
+        throw new Error('changelogPath is required.');
+    }
+
+    if (!options.github) {
+        throw new Error('github is required.');
+    }
+
+    if (!options.github.username) {
+        throw new Error('github username is required.');
+    }
+
+    if (!options.github.token) {
+        throw new Error('github token is required.');
+    }
+
+    if (!options.userAgent) {
+        throw new Error('userAgent is required.');
+    }
+
+    if (!options.uri) {
+        throw new Error('uri is required.');
+    }
+
+    if (!options.tagName) {
+        throw new Error('tagName is required.');
+    }
+
+    if (!options.releaseName) {
+        throw new Error('releaseName is required.');
+    }
+
+    if (options.hasOwnProperty('draft')) {
+        draft = options.draft;
+    }
+
+    if (options.hasOwnProperty('prerelease')) {
+        prerelease = options.prerelease;
+    }
+
+    let content = fs.readFileSync(options.changelogPath).toString('utf8').split(os.EOL);
+    content = localUtils.getEmojiCommits(content);
+
+    content = content.filter((item) => {
+        return item !== undefined;
+    });
+
+    if (options.gistUrl) {
+        content.push('');
+        content.push('You can see the [full change log](' + options.gistUrl + ') for the details of every change included in this release.');
+    }
+
+    const auth = 'Basic ' + new Buffer(options.github.username + ':' + options.github.token).toString('base64');
+
+    const reqOptions = {
+        uri: options.uri,
+        headers: {
+            'User-Agent': options.userAgent,
+            Authorization: auth
+        },
+        method: 'POST',
+        body: {
+            tag_name: options.tagName,
+            target_commitish: 'master',
+            name: options.releaseName,
+            body: content.join(os.EOL),
+            draft: draft,
+            prerelease: prerelease
+        },
+        json: true,
+        resolveWithFullResponse: true
+    };
+
+    return requestPromise(reqOptions)
+        .then((response) => {
+            return {
+                id: response.body.id,
+                releaseUrl: response.body.html_url,
+                uploadUrl: response.body.upload_url
+            };
+        });
+};
+
+module.exports.uploadZip = (options = {}) => {
+    if (!options.github) {
+        throw new Error('github is required.');
+    }
+
+    if (!options.github.username) {
+        throw new Error('github username is required.');
+    }
+
+    if (!options.github.token) {
+        throw new Error('github token is required.');
+    }
+
+    if (!options.zipPath) {
+        throw new Error('github zipPath is required.');
+    }
+
+    if (!options.userAgent) {
+        throw new Error('userAgent is required.');
+    }
+
+    if (!options.uri) {
+        throw new Error('uri is required.');
+    }
+
+    const auth = 'Basic ' + new Buffer(options.github.username + ':' + options.github.token).toString('base64');
+    const stats = fs.statSync(options.zipPath);
+
+    const reqOptions = {
+        uri: options.uri,
+        headers: {
+            'User-Agent': options.userAgent,
+            Authorization: auth,
+            'Content-Type': 'application/zip',
+            'Content-Length': stats.size
+        },
+        method: 'POST',
+        json: true,
+        resolveWithFullResponse: true
+    };
+
+    return new Promise((resolve, reject) => {
+        fs.createReadStream(options.zipPath)
+            .pipe(request.post(reqOptions), (err, res) => {
+                if (err) {
+                    return reject(err);
+                }
+
+                resolve({
+                    downloadUrl: res.body.browser_download_url
+                });
+            });
+    });
+};
+
+module.exports.get = (options = {}) => {
+    if (!options.userAgent) {
+        throw new Error('userAgent is required.');
+    }
+
+    if (!options.uri) {
+        throw new Error('uri is required.');
+    }
+
+    const reqOptions = {
+        uri: options.uri,
+        headers: {
+            'User-Agent': options.userAgent
+        },
+        method: 'GET',
+        json: true
+    };
+
+    return requestPromise(reqOptions)
+        .then((response) => {
+            return response;
+        });
+};

--- a/packages/release-utils/lib/utils.js
+++ b/packages/release-utils/lib/utils.js
@@ -26,7 +26,7 @@ module.exports.filterEmojiCommits = (content) => {
 
 module.exports.checkMissingOptions = (options = {}, ...requiredFields) => {
     const missing = requiredFields.filter((requiredField) => {
-        return !options[requiredField];
+        return !_.get(options, requiredField);
     });
 
     if (missing.length) {

--- a/packages/release-utils/lib/utils.js
+++ b/packages/release-utils/lib/utils.js
@@ -20,3 +20,12 @@ module.exports.getEmojiCommits = (content) => {
 
     return content;
 };
+
+const get = o => p => p.split('.').reduce((obj, prop) => obj && obj[prop], o);
+module.exports.checkMissingOptions = (options = {}, ...fields) => {
+    const missing = options.filter(get(fields));
+
+    if (missing.length) {
+        throw new Error(`Missing options: ${missing.join(',')}`);
+    }
+};

--- a/packages/release-utils/lib/utils.js
+++ b/packages/release-utils/lib/utils.js
@@ -1,0 +1,22 @@
+const emojiRegex = require('emoji-regex');
+
+module.exports.getEmojiCommits = (content) => {
+    content.forEach(function (line, index, obj) {
+        const sqbracket = line.substring(line.indexOf('['), line.indexOf(']') + 1);
+        const rdbracket = line.substring(line.indexOf('('), line.indexOf(')') + 2);
+        const contributor = line.substring(line.lastIndexOf('-') - 1, line.length);
+
+        line = line.replace(sqbracket, '');
+        line = line.replace(rdbracket, '');
+        line = line.replace(contributor, '');
+        obj[index] = line;
+
+        const match = emojiRegex().exec(line);
+
+        if (!match || (match && match.index !== 2)) {
+            delete obj[index];
+        }
+    });
+
+    return content;
+};

--- a/packages/release-utils/lib/utils.js
+++ b/packages/release-utils/lib/utils.js
@@ -1,31 +1,35 @@
 const emojiRegex = require('emoji-regex');
+const _ = require('lodash');
 
-module.exports.getEmojiCommits = (content) => {
-    content.forEach(function (line, index, obj) {
+module.exports.filterEmojiCommits = (content) => {
+    if (!_.isArray(content)) {
+        throw new Error('Expected array of strings.');
+    }
+
+    content = content.filter(function (line, index, obj) {
         const sqbracket = line.substring(line.indexOf('['), line.indexOf(']') + 1);
         const rdbracket = line.substring(line.indexOf('('), line.indexOf(')') + 2);
         const contributor = line.substring(line.lastIndexOf('-') - 1, line.length);
 
+        // NOTE: modify original line
         line = line.replace(sqbracket, '');
         line = line.replace(rdbracket, '');
         line = line.replace(contributor, '');
         obj[index] = line;
 
         const match = emojiRegex().exec(line);
-
-        if (!match || (match && match.index !== 2)) {
-            delete obj[index];
-        }
+        return match && match.index !== 2;
     });
 
     return content;
 };
 
-const get = o => p => p.split('.').reduce((obj, prop) => obj && obj[prop], o);
-module.exports.checkMissingOptions = (options = {}, ...fields) => {
-    const missing = options.filter(get(fields));
+module.exports.checkMissingOptions = (options = {}, ...requiredFields) => {
+    const missing = requiredFields.filter((requiredField) => {
+        return !options[requiredField];
+    });
 
     if (missing.length) {
-        throw new Error(`Missing options: ${missing.join(',')}`);
+        throw new Error(`Missing options: ${missing.join(', ')}`);
     }
 };

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -24,11 +24,11 @@
   },
   "dependencies": {
     "bluebird": "^3.5.3",
-    "emoji-regex": "8.0.0",
-    "execa": "1.0.0",
+    "emoji-regex": "^8.0.0",
+    "execa": "^1.0.0",
     "ghost-ignition": "^3.0.3",
     "lodash": "^4.17.11",
-    "request": "2.88.0",
-    "request-promise": "4.2.4"
+    "request": "^2.88.0",
+    "request-promise": "^4.2.4"
   }
 }

--- a/packages/release-utils/package.json
+++ b/packages/release-utils/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@tryghost/release-utils",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost-Utils/tree/master/packages/release-utils",
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "test": "NODE_ENV=testing mocha './test/**/*.test.js'",
+    "lint": "eslint . --ext .js --cache",
+    "posttest": "yarn lint"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "mocha": "6.0.2",
+    "should": "13.2.3",
+    "sinon": "7.2.7"
+  },
+  "dependencies": {
+    "bluebird": "^3.5.3",
+    "emoji-regex": "8.0.0",
+    "execa": "1.0.0",
+    "ghost-ignition": "^3.0.3",
+    "lodash": "^4.17.11",
+    "request": "2.88.0",
+    "request-promise": "4.2.4"
+  }
+}

--- a/packages/release-utils/test/.eslintrc.js
+++ b/packages/release-utils/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test',
+    ]
+};

--- a/packages/release-utils/test/draft-release.test.js
+++ b/packages/release-utils/test/draft-release.test.js
@@ -1,9 +1,0 @@
-// Switch these lines once there are useful utils
-// const testUtils = require('./utils');
-require('./utils');
-
-describe('Draft Release', function () {
-    it('', function () {
-
-    });
-});

--- a/packages/release-utils/test/draft-release.test.js
+++ b/packages/release-utils/test/draft-release.test.js
@@ -1,0 +1,9 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+
+describe('Draft Release', function () {
+    it('', function () {
+
+    });
+});

--- a/packages/release-utils/test/releases.test.js
+++ b/packages/release-utils/test/releases.test.js
@@ -19,9 +19,9 @@ describe('Releases', function () {
 
         it('missing options', function (done) {
             try {
-                lib.releases.uploadZip({zipPath: 'test'});
+                lib.releases.uploadZip({zipPath: 'test', github: {username: 'test'}});
             } catch (err) {
-                err.message.should.eql('Missing options: github, github.username, github.token, userAgent, uri');
+                err.message.should.eql('Missing options: github.token, userAgent, uri');
                 return done();
             }
 

--- a/packages/release-utils/test/releases.test.js
+++ b/packages/release-utils/test/releases.test.js
@@ -1,0 +1,31 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+
+const lib = require('../lib');
+
+describe('Releases', function () {
+    describe('uploadZip', function () {
+        it('no options', function (done) {
+            try {
+                lib.releases.uploadZip();
+            } catch (err) {
+                err.message.should.eql('Missing options: zipPath, github, github.username, github.token, userAgent, uri');
+                return done();
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('missing options', function (done) {
+            try {
+                lib.releases.uploadZip({zipPath: 'test'});
+            } catch (err) {
+                err.message.should.eql('Missing options: github, github.username, github.token, userAgent, uri');
+                return done();
+            }
+
+            throw new Error('should fail');
+        });
+    });
+});

--- a/packages/release-utils/test/utils.test.js
+++ b/packages/release-utils/test/utils.test.js
@@ -1,0 +1,27 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+
+const lib = require('../lib');
+
+describe('Utils', function () {
+    describe('filterEmojiCommits', function () {
+        it('no emoji commits found', function () {
+            const result = lib.utils.filterEmojiCommits([
+                '[f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name',
+                '[f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name'
+            ]);
+
+            result.length.should.eql(0);
+        });
+
+        it('emoji commits found', function () {
+            const result = lib.utils.filterEmojiCommits([
+                '[f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) Version bump to 2.17.1 - Name',
+                '[f6f35ebcd](https://github.com/TryGhost/Ghost/commit/f6f35ebcd) 👻 Version bump to 2.17.1 - Name'
+            ]);
+
+            result.length.should.eql(1);
+        });
+    });
+});

--- a/packages/release-utils/test/utils/assertions.js
+++ b/packages/release-utils/test/utils/assertions.js
@@ -1,0 +1,11 @@
+/**
+ * Custom Should Assertions
+ *
+ * Add any custom assertions to this file.
+ */
+
+// Example Assertion
+// should.Assertion.add('ExampleAssertion', function () {
+//     this.params = {operator: 'to be a valid Example Assertion'};
+//     this.obj.should.be.an.Object;
+// });

--- a/packages/release-utils/test/utils/index.js
+++ b/packages/release-utils/test/utils/index.js
@@ -1,0 +1,11 @@
+/**
+ * Test Utilities
+ *
+ * Shared utils for writing tests
+ */
+
+// Require overrides - these add globals for tests
+require('./overrides');
+
+// Require assertions - adds custom should assertions
+require('./assertions');

--- a/packages/release-utils/test/utils/overrides.js
+++ b/packages/release-utils/test/utils/overrides.js
@@ -1,0 +1,10 @@
+// This file is required before any test is run
+
+// Taken from the should wiki, this is how to make should global
+// Should is a global in our eslint test config
+global.should = require('should').noConflict();
+should.extend();
+
+// Sinon is a simple case
+// Sinon is a global in our eslint test config
+global.sinon = require('sinon');

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,38 +16,18 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.1":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.1":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/commons@^1.0.2":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
-  dependencies:
-    type-detect "4.0.8"
-
-"@sinonjs/formatio@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.1.0.tgz#6ac9d1eb1821984d84c4996726e45d1646d8cce5"
-  dependencies:
-    "@sinonjs/samsam" "^2 || ^3"
-
-"@sinonjs/formatio@^3.2.1":
+"@sinonjs/formatio@^3.1.0", "@sinonjs/formatio@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
   dependencies:
     "@sinonjs/commons" "^1"
     "@sinonjs/samsam" "^3.1.0"
-
-"@sinonjs/samsam@^2 || ^3":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.0.2.tgz#304fb33bd5585a0b2df8a4c801fcb47fa84d8e43"
-  dependencies:
-    "@sinonjs/commons" "^1.0.2"
-    array-from "^2.1.1"
-    lodash.get "^4.4.2"
 
 "@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.2.0":
   version "3.3.0"
@@ -69,7 +49,7 @@ acorn@^6.0.7:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
 
-ajv@^6.9.1:
+ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   dependencies:
@@ -93,10 +73,6 @@ ansi-regex@^2.0.0:
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-
-ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
 
 ansi-regex@^4.1.0:
   version "4.1.0"
@@ -134,6 +110,16 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
+asn1@~0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -142,9 +128,25 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
+async@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -161,6 +163,16 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  dependencies:
+    tweetnacl "^0.14.3"
+
+bluebird@^3.5.0, bluebird@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -188,6 +200,22 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
+bunyan-loggly@^1.3.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/bunyan-loggly/-/bunyan-loggly-1.4.1.tgz#b6c806fb34bfcde2ce0d98878cf3534620b969e7"
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    node-loggly-bulk "^2.2.4"
+
+bunyan@1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.10.6"
+    mv "~2"
+    safe-json-stringify "~1"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -202,13 +230,25 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+caller@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/caller/-/caller-1.0.1.tgz#b851860f70e195db3d277395aa1a7e23ea30ecf5"
+
 callsites@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
 
+camelcase@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+
 camelcase@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.2.0.tgz#e7522abda5ed94cc0489e1b8466610e88404cf45"
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -241,6 +281,14 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
+cliui@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -270,6 +318,16 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+colors@^1.1.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -282,6 +340,10 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -292,13 +354,19 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  dependencies:
+    assert-plus "^1.0.0"
+
 debug@3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
     ms "^2.1.1"
 
-debug@^2.2.0, debug@^2.3.3:
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -310,7 +378,7 @@ debug@^4.0.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.2.0:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -347,6 +415,10 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
@@ -361,9 +433,26 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dtrace-provider@~0.8:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
+  dependencies:
+    nan "^2.10.0"
+
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
 ember-rfc176-data@^0.3.5:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.6.tgz#7138db8dfccec39c9a832adfbd4c49d670028907"
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.7.tgz#ecff7d74987d09296d3703343fed934515a4be33"
+
+emoji-regex@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -506,7 +595,7 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-execa@^1.0.0:
+execa@1.0.0, execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
   dependencies:
@@ -549,6 +638,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
@@ -569,6 +662,14 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -602,6 +703,10 @@ fill-range@^4.0.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
+
+find-root@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -640,11 +745,31 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
   dependencies:
     map-cache "^0.2.2"
+
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -672,6 +797,29 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  dependencies:
+    assert-plus "^1.0.0"
+
+ghost-ignition@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/ghost-ignition/-/ghost-ignition-3.0.4.tgz#b951140d2734cd8ff48006f3c1de640499b1028c"
+  dependencies:
+    bunyan "1.8.12"
+    bunyan-loggly "^1.3.1"
+    caller "1.0.1"
+    debug "^2.6.9"
+    find-root "1.1.0"
+    fs-extra "^3.0.1"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.16.4"
+    moment "^2.15.2"
+    nconf "^0.10.0"
+    prettyjson "^1.1.3"
+    uuid "^3.0.0"
+
 glob@7.1.3, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -680,6 +828,16 @@ glob@7.1.3, glob@^7.1.2, glob@^7.1.3:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -702,12 +860,27 @@ global-prefix@^1.0.1:
     which "^1.2.14"
 
 globals@^11.7.0:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
+
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
+har-validator@~5.1.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  dependencies:
+    ajv "^6.5.5"
+    har-schema "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -760,6 +933,14 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
 iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -792,7 +973,7 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.4:
+ini@^1.3.0, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
@@ -813,6 +994,10 @@ inquirer@^6.2.2:
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
     through "^2.3.6"
+
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -936,6 +1121,10 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -962,6 +1151,10 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -974,19 +1167,46 @@ js-yaml@3.12.0:
     esprima "^4.0.0"
 
 js-yaml@^3.12.0:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
 
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+
+json-stringify-safe@5.0.x, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
 
 just-extend@^4.0.2:
   version "4.0.2"
@@ -1012,6 +1232,12 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  dependencies:
+    invert-kv "^1.0.0"
+
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -1032,11 +1258,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
-lodash@^4.17.11:
+lodash@^4.16.4, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -1075,11 +1297,11 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 mem@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.1.0.tgz#aeb9be2d21f47e78af29e4ac5978e8afa2ca5b8a"
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.2.0.tgz#5ee057680ed9cb8dad8a78d820f9a8897a102025"
   dependencies:
     map-age-cleaner "^0.1.1"
-    mimic-fn "^1.0.0"
+    mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
 micromatch@^3.0.4:
@@ -1100,11 +1322,25 @@ micromatch@^3.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+mime-db@~1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.22"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
+  dependencies:
+    mime-db "~1.38.0"
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-minimatch@3.0.4, minimatch@^3.0.4:
+mimic-fn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.0.0.tgz#0913ff0b121db44ef5848242c38bbb35d44cabde"
+
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1114,6 +1350,10 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
@@ -1121,7 +1361,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1155,6 +1395,10 @@ mocha@6.0.2:
     yargs-parser "11.1.1"
     yargs-unparser "1.5.0"
 
+moment@^2.10.6, moment@^2.15.2, moment@^2.18.1:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1166,6 +1410,18 @@ ms@2.1.1, ms@^2.1.1:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.10.0:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -1186,6 +1442,19 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nconf@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/nconf/-/nconf-0.10.0.tgz#da1285ee95d0a922ca6cee75adcf861f48205ad2"
+  dependencies:
+    async "^1.4.0"
+    ini "^1.3.0"
+    secure-keys "^1.0.0"
+    yargs "^3.19.0"
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -1213,6 +1482,14 @@ node-environment-flags@1.0.4:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
+node-loggly-bulk@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/node-loggly-bulk/-/node-loggly-bulk-2.2.4.tgz#bdd8638d97c43ecf1e1831ca98b250968fa6dee9"
+  dependencies:
+    json-stringify-safe "5.0.x"
+    moment "^2.18.1"
+    request ">=2.76.0 <3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -1222,6 +1499,10 @@ npm-run-path@^2.0.0:
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -1285,6 +1566,12 @@ optionator@^0.8.2:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  dependencies:
+    lcid "^1.0.0"
 
 os-locale@^3.0.0:
   version "3.1.0"
@@ -1362,6 +1649,10 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -1370,9 +1661,20 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
+prettyjson@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prettyjson/-/prettyjson-1.2.1.tgz#fcffab41d19cab4dfae5e575e64246619b12d289"
+  dependencies:
+    colors "^1.1.2"
+    minimist "^1.2.0"
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+
+psl@^1.1.24, psl@^1.1.28:
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
 
 pump@^3.0.0:
   version "3.0.0"
@@ -1381,9 +1683,17 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0:
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
+qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -1403,6 +1713,46 @@ repeat-element@^1.1.2:
 repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  dependencies:
+    lodash "^4.17.11"
+
+request-promise@4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request@2.88.0, "request@>=2.76.0 <3.0.0":
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -1444,6 +1794,12 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  dependencies:
+    glob "^6.0.1"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -1456,15 +1812,27 @@ rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
+safe-buffer@^5.0.1, safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+secure-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/secure-keys/-/secure-keys-1.0.0.tgz#f0c82d98a3b139a8776a8808050b824431087fca"
 
 semver@^5.5.0, semver@^5.5.1:
   version "5.6.0"
@@ -1625,12 +1993,30 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+sshpk@^1.7.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
+
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -1667,13 +2053,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
-  dependencies:
-    ansi-regex "^4.0.0"
-
-strip-ansi@^5.1.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.1.0.tgz#55aaa54e33b4c0649a7338a43437b1887d153ec4"
   dependencies:
@@ -1748,9 +2128,33 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+tough-cookie@^2.3.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -1770,6 +2174,10 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -1792,6 +2200,18 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
+uuid@^3.0.0, uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -1807,6 +2227,10 @@ wide-align@1.1.3:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
   dependencies:
     string-width "^1.0.2 || 2"
+
+window-size@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
 wordwrap@~1.0.0:
   version "1.0.0"
@@ -1828,6 +2252,10 @@ write@1.0.3:
   resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
   dependencies:
     mkdirp "^0.5.1"
+
+y18n@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"
@@ -1864,3 +2292,15 @@ yargs@12.0.5, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^3.19.0:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
+  dependencies:
+    camelcase "^2.0.1"
+    cliui "^3.0.3"
+    decamelize "^1.1.1"
+    os-locale "^1.4.0"
+    string-width "^1.0.1"
+    window-size "^0.1.4"
+    y18n "^3.2.0"


### PR DESCRIPTION
Added release-utils.

1. Be able to create changelog.md based on previous version.
1. Be able to merge & clean changelog.md.
1. Create a gist
1. Be able to filter commits by emojis (user facing changes)
1. Be able to create a draft release
1. Be able to upload a release zip to Github

We will discuss if we want to replace any of the toolings. But to avoid breaking everything, we do it iteratively. Our release utils works based on our needs.