### PR TITLE
Added check for Adapter prototype name

### DIFF
--- a/packages/adapter-manager/lib/AdapterManager.js
+++ b/packages/adapter-manager/lib/AdapterManager.js
@@ -112,9 +112,11 @@ module.exports = class AdapterManager {
         const adapter = new Adapter(config);
 
         if (!(adapter instanceof this.baseClasses[adapterType])) {
-            throw new errors.IncorrectUsageError({
-                message: `${adapterType} adapter ${adapterName} does not inherit from the base class.`
-            });
+            if (Object.getPrototypeOf(Adapter).name !== this.baseClasses[adapterType].name) {
+                throw new errors.IncorrectUsageError({
+                    message: `${adapterType} adapter ${adapterName} does not inherit from the base class.`
+                });
+            }
         }
 
         if (!adapter.requiredFns) {


### PR DESCRIPTION
no-issue

This fixes issues when the adapter is using a different "instance" of
the base class, so we check the names are the same.