### PR TITLE
errors: add PasswordResetRequiredError

### DIFF
--- a/packages/errors/lib/errors.js
+++ b/packages/errors/lib/errors.js
@@ -67,6 +67,13 @@ const ghostErrors = {
             errorType: 'HelperWarning',
             hideStack: true
         }, options));
+    },
+    PasswordResetRequiredError: function PasswordResetRequiredError(options) {
+        GhostError.call(this, merge({
+            errorType: 'PasswordResetRequiredError',
+            statusCode: 401,
+            message: 'For security, you need to create a new password. An email has been sent to you with instructions!'
+        }, options));
     }
 };
 


### PR DESCRIPTION
Refs tryghost/ghost#11835

The goal is to completely remove `common/errors` in the core, and this error was added after this package was created. Once this gets released, we will be able to remove the errors file in the core 🥳 